### PR TITLE
Feature/hermes fixes

### DIFF
--- a/Sources/W3wTextField.swift
+++ b/Sources/W3wTextField.swift
@@ -236,11 +236,10 @@ open class W3wTextField: UITextField {
                 for suggestion in suggestions ?? [] {
                     self?.optionArray.append(suggestion)
                     self?.dataArray = self!.optionArray
-                    DispatchQueue.main.async {
-                        if (self?.dataArray.count)! > 0 {
-                            self!.table.reloadData()
-                        }
-                    }
+                }
+                    
+                DispatchQueue.main.async {
+                        self!.table.reloadData()
                 }
             }
         }

--- a/Sources/W3wTextField.swift
+++ b/Sources/W3wTextField.swift
@@ -515,17 +515,25 @@ extension W3wTextField : UITextFieldDelegate {
             if (( place?.coordinates ) != nil)
             {
                 DispatchQueue.main.async {
-                    self.checkMarkView.isHidden = false
-                    self.checkMarkViewUpdatedCompletion(false)
+                    self.showCheckMarkView()
                 }
             } else {
                 DispatchQueue.main.async {
-                    self.checkMarkView.isHidden = true
-                    self.checkMarkViewUpdatedCompletion(true)
+                    self.hideCheckMarkView()
                 }
             }
         }
         return true;
+    }
+    
+    private func hideCheckMarkView() {
+        self.checkMarkView.isHidden = true
+        self.checkMarkViewUpdatedCompletion(true)
+    }
+    
+    private func showCheckMarkView() {
+        self.checkMarkView.isHidden = false
+        self.checkMarkViewUpdatedCompletion(false)
     }
 }
 
@@ -588,7 +596,7 @@ extension W3wTextField: UITableViewDelegate {
             touchAction()
             self.endEditing(true)
         }
-        checkMarkView.isHidden = false
+        showCheckMarkView()
         didSelectCompletion(selectedText.words )
     }
 }


### PR DESCRIPTION
Fixes crash when selecting from drop down.  If user types words and dropdown is showing but then deletes past the second dot the suggestion don't disappear allowing the user select and index out of range.

If user selects from drop down this will display the green tick just as if they had typed a valid what3words address.

Adds`func checkMarkViewUpdated` to give a call back that the what3words is valid or not.  This means we can be notified if the user typed a valid address and didn't select one.
